### PR TITLE
fix: updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/update-rust-toolchain.yaml
+++ b/updatecli/updatecli.d/update-rust-toolchain.yaml
@@ -1,4 +1,4 @@
-title: Update Rust version inside of rust-toolchain file
+name: Update Rust version inside of rust-toolchain file
 
 scms:
   github:
@@ -6,15 +6,12 @@ scms:
     spec:
       user: "{{ .github.author }}"
       email: "{{ .github.email }}"
-      directory: "/tmp/wapc-rs"
       owner: "{{ requiredEnv .github.owner }}"
       repository: "wapc-rs"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
       commitmessage:
-        type: "fix"
-        title: "Update Rust version"
         hidecredit: true
 
 sources:
@@ -25,22 +22,22 @@ sources:
       owner: rust-lang
       repository: rust
       token: "{{ requiredEnv .github.token }}"
-    transformers:
-      - find: '(\d+\.\d+\.\d+)'
+      versionfilter:
+        kind: semver
+        pattern: "*"
 
 targets:
   dataFile:
-    name: Bump Rust release
+    name: 'deps(rust): update Rust version to {{ source "rust-lang" }}'
     kind: toml
     scmid: github
     spec:
       file: "rust-toolchain.toml"
       key: toolchain.channel
 
-pullrequests:
+actions:
   default:
-    title: '[updatecli] Update Rust version to {{ source "rust-lang" }}'
-    kind: github
+    kind: github/pullrequest
     scmid: github
     spec:
       labels:


### PR DESCRIPTION
Various improvement

* Field `title` is deprecated in favor of `name` to stay consistent with resource name
* Field `directory` is not needed
* Commit `type` and `title` are useless as now the commit title is defined by the target name by default
* Transformers is useless in the source
* Adding version filter of kind semver to always fetch the latest version from a semantic versioning point of view
* `pullrequest` has been deprecated for `actions` which is more generic

I tested my changes on https://github.com/olblak/wapc-rs/pull/2